### PR TITLE
Remove OSM version requirement and auto upgrade check

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/OpenServiceMesh.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/OpenServiceMesh.py
@@ -9,7 +9,7 @@
 
 from knack.log import get_logger
 
-from azure.cli.core.azclierror import InvalidArgumentValueError, RequiredArgumentMissingError
+from azure.cli.core.azclierror import InvalidArgumentValueError
 from azure.cli.core.commands.client_factory import get_subscription_id
 
 from packaging import version
@@ -52,16 +52,6 @@ class OpenServiceMesh(PartnerExtensionModel):
 
         scope_cluster = ScopeCluster(release_namespace=release_namespace)
         ext_scope = Scope(cluster=scope_cluster, namespace=None)
-
-        # version is a mandatory if release-train is staging or pilot
-        if version is None:
-            raise RequiredArgumentMissingError(
-                "A version must be provided for release-train {}.".format(release_train)
-            )
-        # If the release-train is 'staging' or 'pilot' then auto-upgrade-minor-version MUST be set to False
-        if auto_upgrade_minor_version or auto_upgrade_minor_version is None:
-            auto_upgrade_minor_version = False
-            logger.warning("Setting auto-upgrade-minor-version to False since release-train is '%s'", release_train)
 
         # NOTE-2: Return a valid ExtensionInstance object, Instance name and flag for Identity
         create_identity = False


### PR DESCRIPTION
This PR removes the version check for the Open Service Mesh part of the extension. By passing in no version, we can allow the platform to choose the latest version in the specified release train.

This also removes the check for auto upgrade minor version. Again, it is best to allow the platform to determine if auto upgrade should be set if not explicitly passed in. The platform will do the following:

- Set auto upgrade to true if there is no version specified (defaulting to latest for the release train)
- Set auto upgrade to false if there is a specified version

### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
