### PR TITLE
CI fix: deprecate python version 3.6 use in testing

### DIFF
--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -72,9 +72,9 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.6'
+      displayName: 'Use Python 3.10'
       inputs:
-        versionSpec: 3.6
+        versionSpec: 3.10
     - bash: |
         set -ev
 
@@ -117,9 +117,9 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
     - task: UsePythonVersion@0
-      displayName: 'Use Python 3.7'
+      displayName: 'Use Python 3.10'
       inputs:
-        versionSpec: 3.7
+        versionSpec: 3.10
     - bash: |
         #!/usr/bin/env bash
         set -ev
@@ -138,6 +138,10 @@ stages:
           python.version: '3.6'
         Python38:
           python.version: '3.8'
+        Python39:
+          python.version: '3.9'
+        Python310:
+          python.version: '3.10'
     steps:
       - task: UsePythonVersion@0
         displayName: 'Use Python $(python.version)'
@@ -171,9 +175,9 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.6'
+        displayName: 'Use Python 3.10'
         inputs:
-          versionSpec: 3.6
+          versionSpec: 3.10
       - bash: |
           set -ev
 

--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -103,9 +103,9 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.6'
+        displayName: 'Use Python 3.10'
         inputs:
-          versionSpec: 3.6
+          versionSpec: 3.10
       - bash: pip install wheel==0.30.0 pylint==1.9.5 flake8==3.5.0 requests
         displayName: 'Install wheel, pylint, flake8, requests'
       - bash: python scripts/ci/source_code_static_analysis.py

--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -103,9 +103,9 @@ stages:
       vmImage: 'ubuntu-latest'
     steps:
       - task: UsePythonVersion@0
-        displayName: 'Use Python 3.10'
+        displayName: 'Use Python 3.6'
         inputs:
-          versionSpec: 3.10
+          versionSpec: 3.6
       - bash: pip install wheel==0.30.0 pylint==1.9.5 flake8==3.5.0 requests
         displayName: 'Install wheel, pylint, flake8, requests'
       - bash: python scripts/ci/source_code_static_analysis.py

--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -134,8 +134,6 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        Python36:
-          python.version: '3.6'
         Python38:
           python.version: '3.8'
         Python39:

--- a/testing/pipeline/templates/build-extension.yml
+++ b/testing/pipeline/templates/build-extension.yml
@@ -27,9 +27,9 @@ steps:
   condition: and(succeeded(), eq(variables['IS_PRIVATE_BRANCH'], 'False'))
   displayName: "Copy Files, Set Variables for k8s-extension"
 - task: UsePythonVersion@0
-  displayName: 'Use Python 3.10'
+  displayName: 'Use Python 3.6'
   inputs:
-    versionSpec: 3.10
+    versionSpec: 3.6
 - bash: |
     set -ev
     echo "Building extension ${EXTENSION_NAME}..."

--- a/testing/pipeline/templates/build-extension.yml
+++ b/testing/pipeline/templates/build-extension.yml
@@ -27,9 +27,9 @@ steps:
   condition: and(succeeded(), eq(variables['IS_PRIVATE_BRANCH'], 'False'))
   displayName: "Copy Files, Set Variables for k8s-extension"
 - task: UsePythonVersion@0
-  displayName: 'Use Python 3.6'
+  displayName: 'Use Python 3.10'
   inputs:
-    versionSpec: 3.6
+    versionSpec: 3.10
 - bash: |
     set -ev
     echo "Building extension ${EXTENSION_NAME}..."


### PR DESCRIPTION
Fix for CI failure issues: [Issue description(pr link)](https://github.com/Azure/azure-cli-extensions/pull/5218)


---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
