### PR TITLE
[Dapr] Add Dapr tests to test pipeline

### DIFF
--- a/testing/pipeline/k8s-custom-pipelines.yml
+++ b/testing/pipeline/k8s-custom-pipelines.yml
@@ -43,6 +43,10 @@ stages:
       path: ./test/extensions/public/Cassandra.Tests.ps1
   - template: ./templates/run-test.yml
     parameters:
+      jobName: Dapr
+      path: ./test/extensions/public/Dapr.Tests.ps1
+  - template: ./templates/run-test.yml
+    parameters:
       jobName: ExtensionTypes
       path: ./test/extensions/public/ExtensionTypes.Tests.ps1
   - template: ./templates/run-test.yml


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

---

Dapr test was added in #188 but not added to the test pipeline, this PR adds that.


### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->

`az k8s-extension`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
