### PR TITLE
[Dapr] Update version comparison logic to use semver based comparison

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
@@ -206,4 +206,5 @@ class Dapr(DefaultExtension):
         try:
             return packaging_version.Version(v1) < packaging_version.Version(v2)
         except packaging_version.InvalidVersion:
-            return False
+            logger.debug("Warning: Unable to compare versions %s and %s.", v1, v2)
+            return True  # This will cause the apply-CRDs hook to be disabled, which is safe.

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
@@ -13,6 +13,7 @@ from azure.cli.core.azclierror import InvalidArgumentValueError
 from copy import deepcopy
 from knack.log import get_logger
 from knack.prompting import prompt, prompt_y_n
+from packaging import version as packaging_version
 
 from ..vendored_sdks.models import Extension, PatchExtension, Scope, ScopeCluster
 from .DefaultExtension import DefaultExtension
@@ -173,7 +174,7 @@ class Dapr(DefaultExtension):
             logger.debug("Auto-upgrade is disabled and version is pinned to %s. Setting '%s' to false.",
                          version, self.APPLY_CRDS_HOOK_ENABLED_KEY)
             configuration_settings[self.APPLY_CRDS_HOOK_ENABLED_KEY] = 'false'
-        elif original_version and version and version < original_version:
+        elif original_version and version and Dapr._is_downgrade(version, original_version):
             logger.debug("Downgrade detected from %s to %s. Setting %s to false.",
                          original_version, version, self.APPLY_CRDS_HOOK_ENABLED_KEY)
             configuration_settings[self.APPLY_CRDS_HOOK_ENABLED_KEY] = 'false'
@@ -196,3 +197,13 @@ class Dapr(DefaultExtension):
                               version=version,
                               configuration_settings=configuration_settings,
                               configuration_protected_settings=configuration_protected_settings)
+
+    @staticmethod
+    def _is_downgrade(v1: str, v2: str) -> bool:
+        """
+        Returns True if version v1 is less than version v2.
+        """
+        try:
+            return packaging_version.Version(v1) < packaging_version.Version(v2)
+        except packaging_version.InvalidVersion:
+            return False


### PR DESCRIPTION
---
This PR updates the version comparison logic in Dapr extension. Earlier, it was using a string comparison, this PR upgrades it to use semver using `packaging.version`.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repository and upgrade the version in the pull request but do not modify `src/index.json`. 
