### PR TITLE
Add support to skip provisioning of prerequisites for Azure Monitor K8s extensions

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/AzureMonitorMetrics.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/AzureMonitorMetrics.py
@@ -60,7 +60,7 @@ class AzureMonitorMetrics(DefaultExtension):
                 cluster_type
             )
         else:
-            logger.info("Provisioning to prerequisites is skipped")
+            logger.info("Provisioning of prerequisites is skipped")
 
         create_identity = True
         extension = Extension(
@@ -83,7 +83,7 @@ class AzureMonitorMetrics(DefaultExtension):
 
         if (extension is not None) and (extension.configuration_settings is not None):
             if is_skip_prerequisites_specified(extension.configuration_settings):
-                logger.info("Deprovisioning to prerequisites is skipped")
+                logger.info("Deprovisioning of prerequisites is skipped")
                 return
 
         cluster_subscription = get_subscription_id(cmd.cli_ctx)

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/AzureMonitorMetrics.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/AzureMonitorMetrics.py
@@ -9,7 +9,7 @@ import datetime
 import json
 import re
 
-from ..utils import get_cluster_rp_api_version
+from ..utils import get_cluster_rp_api_version, is_skip_prerequisites_specified
 
 from knack.log import get_logger
 
@@ -48,16 +48,19 @@ class AzureMonitorMetrics(DefaultExtension):
         if release_train is None:
             release_train = 'stable'
 
-        cluster_subscription = get_subscription_id(cmd.cli_ctx)
-        ensure_azure_monitor_profile_prerequisites(
-            cmd,
-            cluster_rp,
-            cluster_subscription,
-            resource_group_name,
-            cluster_name,
-            configuration_settings,
-            cluster_type
-        )
+        if not is_skip_prerequisites_specified(configuration_settings):
+            cluster_subscription = get_subscription_id(cmd.cli_ctx)
+            ensure_azure_monitor_profile_prerequisites(
+                cmd,
+                cluster_rp,
+                cluster_subscription,
+                resource_group_name,
+                cluster_name,
+                configuration_settings,
+                cluster_type
+            )
+        else:
+            logger.info("Provisioning to prerequisites is skipped")
 
         create_identity = True
         extension = Extension(
@@ -72,6 +75,16 @@ class AzureMonitorMetrics(DefaultExtension):
         return extension, name, create_identity
 
     def Delete(self, cmd, client, resource_group_name, cluster_name, name, cluster_type, cluster_rp, yes):
-        # cluster_rp, _ = get_cluster_rp_api_version(cluster_type=cluster_type, cluster_rp=cluster_rp)
+        cluster_rp, _ = get_cluster_rp_api_version(cluster_type=cluster_type, cluster_rp=cluster_rp)
+        try:
+            extension = client.get(resource_group_name, cluster_rp, cluster_type, cluster_name, name)
+        except Exception:
+            pass  # its OK to ignore the exception since MSI auth in preview
+
+        if (extension is not None) and (extension.configuration_settings is not None):
+            if is_skip_prerequisites_specified(extension.configuration_settings):
+                logger.info("Deprovisioning to prerequisites is skipped")
+                return
+
         cluster_subscription = get_subscription_id(cmd.cli_ctx)
         unlink_azure_monitor_profile_artifacts(cmd, cluster_subscription, resource_group_name, cluster_name)

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/ContainerInsights.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/ContainerInsights.py
@@ -9,7 +9,7 @@ import datetime
 import json
 import re
 
-from ..utils import get_cluster_rp_api_version
+from ..utils import get_cluster_rp_api_version, is_skip_prerequisites_specified
 from .. import consts
 
 from knack.log import get_logger
@@ -60,8 +60,11 @@ class ContainerInsights(DefaultExtension):
                        'only supports cluster scope and single instance of this extension.', extension_type)
         logger.warning("Defaulting to extension name '%s' and release-namespace '%s'", name, release_namespace)
 
-        _get_container_insights_settings(cmd, resource_group_name, cluster_rp, cluster_type, cluster_name, configuration_settings,
-                                         configuration_protected_settings, is_ci_extension_type)
+        if not is_skip_prerequisites_specified(configuration_settings):
+            _get_container_insights_settings(cmd, resource_group_name, cluster_rp, cluster_type, cluster_name, configuration_settings,
+                                             configuration_protected_settings, is_ci_extension_type)
+        else:
+            logger.info("Provisioning to prerequisites is skipped")
 
         # NOTE-2: Return a valid Extension object, Instance name and flag for Identity
         create_identity = True
@@ -85,6 +88,11 @@ class ContainerInsights(DefaultExtension):
             extension = client.get(resource_group_name, cluster_rp, cluster_type, cluster_name, name)
         except Exception:
             pass  # its OK to ignore the exception since MSI auth in preview
+
+        if (extension is not None) and (extension.configuration_settings is not None):
+            if is_skip_prerequisites_specified(extension.configuration_settings):
+                logger.info("Deprovisioning to prerequisites is skipped")
+                return
 
         subscription_id = get_subscription_id(cmd.cli_ctx)
         # handle cluster type here

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/ContainerInsights.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/ContainerInsights.py
@@ -64,7 +64,7 @@ class ContainerInsights(DefaultExtension):
             _get_container_insights_settings(cmd, resource_group_name, cluster_rp, cluster_type, cluster_name, configuration_settings,
                                              configuration_protected_settings, is_ci_extension_type)
         else:
-            logger.info("Provisioning to prerequisites is skipped")
+            logger.info("Provisioning of prerequisites is skipped")
 
         # NOTE-2: Return a valid Extension object, Instance name and flag for Identity
         create_identity = True
@@ -91,7 +91,7 @@ class ContainerInsights(DefaultExtension):
 
         if (extension is not None) and (extension.configuration_settings is not None):
             if is_skip_prerequisites_specified(extension.configuration_settings):
-                logger.info("Deprovisioning to prerequisites is skipped")
+                logger.info("Deprovisioning of prerequisites is skipped")
                 return
 
         subscription_id = get_subscription_id(cmd.cli_ctx)

--- a/src/k8s-extension/azext_k8s_extension/utils.py
+++ b/src/k8s-extension/azext_k8s_extension/utils.py
@@ -54,3 +54,17 @@ def is_dogfood_cluster(cmd):
         urlparse(cmd.cli_ctx.cloud.endpoints.resource_manager).hostname
         == consts.DF_RM_HOSTNAME
     )
+
+
+def is_skip_prerequisites_specified(configuration_settings):
+    # Determine if provisioning to prerequisites should be skipped by a configuration setting named skipPrerequisites.
+    SKIP_PREQUISITES = 'skipPrerequisites'
+
+    has_skip_prerequisites_set = False
+
+    if SKIP_PREQUISITES in configuration_settings:
+        skip_prerequisites_configuration_setting = configuration_settings[SKIP_PREQUISITES]
+        if (isinstance(skip_prerequisites_configuration_setting, str) and str(skip_prerequisites_configuration_setting).lower() == "true") or (isinstance(skip_prerequisites_configuration_setting, bool) and skip_prerequisites_configuration_setting):
+            has_skip_prerequisites_set = True
+
+    return has_skip_prerequisites_set


### PR DESCRIPTION
This PR will introduce a new 'virtual' configuration setting named `skipPrerequisites` for Azure Monitor K8s extensions. When it's set as `true`, CLI will skip provisioning/deprovisioning of prerequisites considering the below scenarios:
- Advanced users want to create those prerequisites and fill in the related configuration settings by themselves.
- For some cloud, some ARM resource types in prerequisites are not support.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
