### PR TITLE
[Dapr] Use `semver` instead of `packaging`

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/Dapr.py
@@ -13,7 +13,7 @@ from azure.cli.core.azclierror import InvalidArgumentValueError
 from copy import deepcopy
 from knack.log import get_logger
 from knack.prompting import prompt, prompt_y_n
-from packaging import version as packaging_version
+from semver import VersionInfo
 
 from ..vendored_sdks.models import Extension, PatchExtension, Scope, ScopeCluster
 from .DefaultExtension import DefaultExtension
@@ -204,7 +204,7 @@ class Dapr(DefaultExtension):
         Returns True if version v1 is less than version v2.
         """
         try:
-            return packaging_version.Version(v1) < packaging_version.Version(v2)
-        except packaging_version.InvalidVersion:
+            return VersionInfo.parse(v1) < VersionInfo.parse(v2)
+        except ValueError:
             logger.debug("Warning: Unable to compare versions %s and %s.", v1, v2)
             return True  # This will cause the apply-CRDs hook to be disabled, which is safe.


### PR DESCRIPTION
---

`packaging.version` had some short comings, viz. it can parse currently supported Dapr versions but not the ones that we will introduce in future. This can be fixed by using the `semver` package. azure-cli already depends on semver==2.13.0 https://github.com/Azure/azure-cli/blob/dev/src/azure-cli/setup.py which we can leverage (similar to the fleet extension).

![image](https://github.com/AzureArcForKubernetes/azure-cli-extensions/assets/22132944/6a53eb17-abef-430a-add2-c05fb70f06b8)

This PR uses semver to parse versions and compare them (to check for downgrades).

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
