### PR TITLE
Fix osm-arc version check for CI tags

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/OpenServiceMesh.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/OpenServiceMesh.py
@@ -71,7 +71,6 @@ class OpenServiceMesh(DefaultExtension):
 
 def _validate_tested_distro(cmd, cluster_resource_group_name, cluster_name, extension_version, extension_release_train):
 
-    logger.warning("Running validated distros...")
     field_unavailable_error = '\"testedDistros\" field unavailable for version {0} of microsoft.openservicemesh, ' \
         'cannot determine if this Kubernetes distribution has been properly tested'.format(extension_version)
 
@@ -104,7 +103,10 @@ def _validate_tested_distro(cmd, cluster_resource_group_name, cluster_name, exte
 
         extension_version = tags[len(tags) - 1]
 
-    if version.parse(str(extension_version)) <= version.parse("0.8.3"):
+    ext_str = str(extension_version)
+
+    # Don't parse version for test and CI tags
+    if "pr" not in ext_str and "release" not in ext_str and version.parse(ext_str) <= version.parse("0.8.3"):
         logger.warning(field_unavailable_error)
         return
 


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

Currently, after the update to Python3.9, the versioning check as part of the OSM-Arc distro validations will fail and block installation for OSM-Arc test image tags that are used as part of our CI/CD pipelines. To unblock the OSM-Arc CI/CD workflow and release process, this change is needed to only perform the semver check for prod OSM-Arc charts. 

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
