### PR TITLE
Remove useless snippets

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/__cmd_group.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/__cmd_group.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command_group(
-    "relay",
-)
 class __CMDGroup(AAZCommandGroup):
     """Manage Azure Relay Service namespaces, WCF relays, hybrid connections, and rules.
     """

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/__cmd_group.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/__cmd_group.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command_group(
-    "relay hyco",
-)
 class __CMDGroup(AAZCommandGroup):
     """Manage Azure Relay Service Hybrid Connection and Authorization Rule.
     """

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/_create.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/_create.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command(
-    "relay hyco create",
-)
 class Create(AAZCommand):
     """Create the Relay Service Hybrid Connection.
 

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/_show.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/_show.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command(
-    "relay hyco show",
-)
 class Show(AAZCommand):
     """Shows the Relay Service Hybrid Connection Details.
 

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/__cmd_group.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/__cmd_group.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command_group(
-    "relay hyco authorization-rule",
-)
 class __CMDGroup(AAZCommandGroup):
     """Manage Azure Relay Service Hybrid Connection Authorization Rule.
     """

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/_create.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/_create.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command(
-    "relay hyco authorization-rule create",
-)
 class Create(AAZCommand):
     """Create Authorization Rule for given Relay Service Hybrid Connection.
 

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/keys/__cmd_group.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/keys/__cmd_group.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command_group(
-    "relay hyco authorization-rule keys",
-)
 class __CMDGroup(AAZCommandGroup):
     """Manage Azure Authorization Rule keys for Relay Service Hybrid Connection.
     """

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/keys/_list.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/hyco/authorization_rule/keys/_list.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command(
-    "relay hyco authorization-rule keys list",
-)
 class List(AAZCommand):
     """List the keys and connection strings of Authorization Rule for Relay Service Hybrid Connection.
 

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/namespace/__cmd_group.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/namespace/__cmd_group.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command_group(
-    "relay namespace",
-)
 class __CMDGroup(AAZCommandGroup):
     """Manage Azure Relay Service Namespace.
     """

--- a/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/namespace/_create.py
+++ b/src/k8s-extension/azext_k8s_extension/aaz/latest/relay/namespace/_create.py
@@ -11,9 +11,6 @@
 from azure.cli.core.aaz import *
 
 
-@register_command(
-    "relay namespace create",
-)
 class Create(AAZCommand):
     """Create a Relay Service Namespace.
 


### PR DESCRIPTION
Actually, it's a fix of https://github.com/AzureArcForKubernetes/azure-cli-extensions/pull/254. It incorrectly exposed relay related commands.

For more details, we only use them within the implementation, for that case, we don’t need `register_command` or `register_command_group`.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
