### PR TITLE
microsoft.workloadiam: Refactor subcommand invocation

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/WorkloadIAM.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/WorkloadIAM.py
@@ -45,6 +45,15 @@ class WorkloadIAM(DefaultExtension):
             # TODO - Set this to 'stable' when the extension is ready
             release_train = 'preview'
 
+        # The name is used as a base to generate Kubernetes labels for config maps, pods, etc, and
+        # their names are limited to 63 characters (RFC-1123). Instead of calculating the exact
+        # number of characters that we can allow users to specify, it's better to restrict that even
+        # more so that we have extra space in case the name of a resource changes and it pushes the
+        # total string length over the limit.
+        if len(name) > 20:
+            raise InvalidArgumentValueError(
+                f"Name '{name}' is too long, it must be 20 characters long max.")
+
         scope = scope.lower()
         if scope is None:
             scope = 'cluster'

--- a/src/k8s-extension/azext_k8s_extension/tests/latest/test_workload_iam.py
+++ b/src/k8s-extension/azext_k8s_extension/tests/latest/test_workload_iam.py
@@ -25,6 +25,27 @@ from unittest.mock import patch
 
 class TestWorkloadIAM(unittest.TestCase):
 
+    def test_workload_iam_create_with_instance_name_too_long(self):
+        """
+        Test that the checks fail when the user provides an instance name that is too long.
+        """
+
+        instance_name = "workload-iam-extra-long-instance-name"
+
+        with self.assertRaises(InvalidArgumentValueError) as context:
+            workload_iam = WorkloadIAM()
+            workload_iam.Create(cmd=None, client=None, resource_group_name=None,
+                cluster_name=None, name=instance_name, cluster_type=None, cluster_rp=None,
+                extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
+                release_train='dev', version='0.1.0', target_namespace=None,
+                release_namespace=None, configuration_settings=None,
+                configuration_protected_settings=None, configuration_settings_file=None,
+                configuration_protected_settings_file=None, plan_name=None, plan_publisher=None,
+                plan_product=None)
+
+        self.assertEqual(str(context.exception),
+            f"Name '{instance_name}' is too long, it must be 20 characters long max.")
+
     def test_workload_iam_create_without_join_token_success(self):
         """
         Test that, when the user doesn't provide a join token, the Create() method calls


### PR DESCRIPTION
The old code was unreliable. The new code should work in a similar way but it should be able to handle errors in a more graceful way.

For example, this is the output in a successful run:
![ok](https://github.com/AzureArcForKubernetes/azure-cli-extensions/assets/6632664/dc4ee2b8-654e-4b01-8ce7-2509c79aaa81)

And this is the output in a non-successful run when the user has already used that local authority before and the workload-iam extension fails to create a join token:
![not ok](https://github.com/AzureArcForKubernetes/azure-cli-extensions/assets/6632664/696fde45-8dac-48cb-86f7-ef2d03b1bcef)

It also adds a check to ensure that the instance name isn't too long. The instance name is used to form labels for Kubernetes resources, and their labels are limited to 63 characters. If the instance name is too long, the labels will go over that limit.

https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->


### General Guidelines

- [x] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [x] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
