### PR TITLE
Rename WorkloadIAM to EntraWorkloadIAM

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/custom.py
+++ b/src/k8s-extension/azext_k8s_extension/custom.py
@@ -30,7 +30,7 @@ from .partner_extensions.OpenServiceMesh import OpenServiceMesh
 from .partner_extensions.AzureMLKubernetes import AzureMLKubernetes
 from .partner_extensions.DataProtectionKubernetes import DataProtectionKubernetes
 from .partner_extensions.Dapr import Dapr
-from .partner_extensions.WorkloadIAM import WorkloadIAM
+from .partner_extensions.EntraWorkloadIAM import EntraWorkloadIAM
 from .partner_extensions.DefaultExtension import (
     DefaultExtension,
     user_confirmation_factory,
@@ -52,7 +52,7 @@ def ExtensionFactory(extension_name):
         "microsoft.azureml.kubernetes": AzureMLKubernetes,
         "microsoft.dapr": Dapr,
         "microsoft.dataprotection.kubernetes": DataProtectionKubernetes,
-        "microsoft.workloadiam": WorkloadIAM,
+        "microsoft.entraworkloadiam": EntraWorkloadIAM,
     }
 
     # Return the extension if we find it in the map, else return the default

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
@@ -28,7 +28,7 @@ CONFIG_SETTINGS_HELM_TENANT_ID = 'global.workload-iam.tenantID'
 CONFIG_SETTINGS_HELM_JOIN_TOKEN = 'workload-iam-local-authority.localAuthorityArgs.joinToken'
 
 
-class WorkloadIAM(DefaultExtension):
+class EntraWorkloadIAM(DefaultExtension):
 
     def Create(self, cmd, client, resource_group_name, cluster_name, name, cluster_type, cluster_rp,
                extension_type, scope, auto_upgrade_minor_version, release_train, version, target_namespace,
@@ -36,7 +36,7 @@ class WorkloadIAM(DefaultExtension):
                configuration_settings_file, configuration_protected_settings_file,
                plan_name, plan_publisher, plan_product):
         """
-        Create method for ExtensionType 'microsoft.workloadiam'.
+        Create method for ExtensionType 'microsoft.entraworkloadiam'.
         """
 
         # Ensure that the values provided by the user for generic values of Arc extensions are

--- a/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
+++ b/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
@@ -8,8 +8,8 @@
 import unittest
 
 from azure.cli.core.azclierror import InvalidArgumentValueError
-from azext_k8s_extension.partner_extensions.WorkloadIAM import (
-    WorkloadIAM,
+from azext_k8s_extension.partner_extensions.EntraWorkloadIAM import (
+    EntraWorkloadIAM,
     CONFIG_SETTINGS_USER_TRUST_DOMAIN,
     CONFIG_SETTINGS_USER_LOCAL_AUTHORITY,
     CONFIG_SETTINGS_USER_TENANT_ID,
@@ -23,7 +23,7 @@ from knack.util import CLIError
 
 from unittest.mock import patch
 
-class TestWorkloadIAM(unittest.TestCase):
+class TestEntraWorkloadIAM(unittest.TestCase):
 
     def test_workload_iam_create_with_instance_name_too_long(self):
         """
@@ -33,7 +33,7 @@ class TestWorkloadIAM(unittest.TestCase):
         instance_name = "workload-iam-extra-long-instance-name"
 
         with self.assertRaises(InvalidArgumentValueError) as context:
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name=instance_name, cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -72,13 +72,13 @@ class TestWorkloadIAM(unittest.TestCase):
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
 
-        with patch('azext_k8s_extension.partner_extensions.WorkloadIAM.Extension.__init__',
+        with patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.Extension.__init__',
                 new=mock_extension_init), \
-            patch('azext_k8s_extension.partner_extensions.WorkloadIAM.WorkloadIAM.get_join_token',
+            patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.EntraWorkloadIAM.get_join_token',
                 return_value=mock_join_token):
 
             # Test & assert
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             _, name, _ = workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -118,13 +118,13 @@ class TestWorkloadIAM(unittest.TestCase):
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
 
-        with patch('azext_k8s_extension.partner_extensions.WorkloadIAM.Extension.__init__',
+        with patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.Extension.__init__',
                 new=mock_extension_init), \
-            patch('azext_k8s_extension.partner_extensions.WorkloadIAM.WorkloadIAM.get_join_token',
+            patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.EntraWorkloadIAM.get_join_token',
                 return_value='BAD_JOIN_TOKEN'):
 
             # Test & assert
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             _, name, _ = workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -162,13 +162,13 @@ class TestWorkloadIAM(unittest.TestCase):
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
 
-        with patch('azext_k8s_extension.partner_extensions.WorkloadIAM.Extension.__init__',
+        with patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.Extension.__init__',
                 new=mock_extension_init), \
-            patch('azext_k8s_extension.partner_extensions.WorkloadIAM.WorkloadIAM.get_join_token',
+            patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.EntraWorkloadIAM.get_join_token',
                 return_value='BAD_JOIN_TOKEN'):
 
             # Test & assert
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             _, name, _ = workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -193,7 +193,7 @@ class TestWorkloadIAM(unittest.TestCase):
         }
 
         with self.assertRaises(InvalidArgumentValueError) as context:
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -214,7 +214,7 @@ class TestWorkloadIAM(unittest.TestCase):
         bad_scope = 'namespace'
 
         with self.assertRaises(InvalidArgumentValueError) as context:
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope=bad_scope, auto_upgrade_minor_version=None,
@@ -246,7 +246,7 @@ class TestWorkloadIAM(unittest.TestCase):
         }
 
         with self.assertRaises(InvalidArgumentValueError) as context:
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -268,7 +268,7 @@ class TestWorkloadIAM(unittest.TestCase):
         }
 
         with self.assertRaises(InvalidArgumentValueError) as context:
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             workload_iam.Create(cmd=None, client=None, resource_group_name=None,
                 cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
@@ -304,10 +304,10 @@ class TestWorkloadIAM(unittest.TestCase):
 
                 self.result = MockResult()
 
-        with patch('azext_k8s_extension.partner_extensions.WorkloadIAM.get_default_cli',
+        with patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.get_default_cli',
                    return_value=MockCLI()):
             # Test & assert
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             join_token = workload_iam.get_join_token(mock_trust_domain_name, mock_local_authority_name)
             self.assertEqual(join_token, mock_join_token)
 
@@ -344,10 +344,10 @@ class TestWorkloadIAM(unittest.TestCase):
 
                 self.result = MockResult()
 
-        with patch('azext_k8s_extension.partner_extensions.WorkloadIAM.get_default_cli',
+        with patch('azext_k8s_extension.partner_extensions.EntraWorkloadIAM.get_default_cli',
                    return_value=MockCLI()):
             # Test & assert
-            workload_iam = WorkloadIAM()
+            workload_iam = EntraWorkloadIAM()
             cmd_str = " ".join(cmd)
             self.assertRaisesRegex(CLIError,
                 f"Error while generating a join token. Command: {cmd_str}",


### PR DESCRIPTION
The extension type name of ``microsoft.workloadiam`` has been changed to ``microsoft.entraworkloadiam``. This PR updates ``k8s-extension`` to recognize the new name.

---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
``az k8s-extension``


### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
