### PR TITLE
[EntraWorkloadIAM] Use config protected settings

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
@@ -99,7 +99,7 @@ class EntraWorkloadIAM(DefaultExtension):
         join_token = config_settings.pop(CONFIG_SETTINGS_USER_JOIN_TOKEN, None)
         if join_token is not None:
             raise InvalidArgumentValueError(
-                "The join token must be provided with --config-protected-settings, not "
+                "'joinToken' must be provided with --config-protected-settings, not "
                 "--configuration-settings.")
 
         join_token = config_protected_settings.pop(CONFIG_SETTINGS_USER_JOIN_TOKEN, None)
@@ -117,7 +117,7 @@ class EntraWorkloadIAM(DefaultExtension):
         if join_token is None:
             if local_authority is None:
                 raise InvalidArgumentValueError(
-                    "Invalid configuration settings. Either a join token or a local authority name "
+                    "Invalid configuration settings. One of 'joinToken' or 'localAuthority' "
                     "must be provided.")
             join_token = self.get_join_token(trust_domain, local_authority)
         else:
@@ -132,8 +132,8 @@ class EntraWorkloadIAM(DefaultExtension):
         configuration_protected_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] = join_token
 
         logger.debug("Configuration settings: %s" % str(configuration_settings))
-        logger.debug("Configuration protected settings value for Helm: %s" %
-                     str(configuration_protected_settings))
+        logger.debug("Configuration protected settings keys: %s" %
+                     str(configuration_protected_settings.keys()))
 
         create_identity = True
         extension = Extension(

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/EntraWorkloadIAM.py
@@ -27,6 +27,25 @@ CONFIG_SETTINGS_HELM_TRUST_DOMAIN = 'global.workload-iam.trustDomain'
 CONFIG_SETTINGS_HELM_TENANT_ID = 'global.workload-iam.tenantID'
 CONFIG_SETTINGS_HELM_JOIN_TOKEN = 'workload-iam-local-authority.localAuthorityArgs.joinToken'
 
+def settings_dict_to_lowercase(settings):
+    """
+    Create new dictionary where the keys of the known user settings are all lowercase (but leave the
+    others as they were in case they are specific settings that have to be passed to the Helm chart).
+    """
+    all_user_settings = [CONFIG_SETTINGS_USER_TRUST_DOMAIN, CONFIG_SETTINGS_USER_TENANT_ID,
+                         CONFIG_SETTINGS_USER_LOCAL_AUTHORITY, CONFIG_SETTINGS_USER_JOIN_TOKEN]
+
+    if settings is None:
+        return dict()
+
+    validated_settings = dict()
+    for key, value in settings.items():
+        if key.lower() in all_user_settings:
+            validated_settings[key.lower()] = value
+        else:
+            validated_settings[key] = value
+
+    return validated_settings
 
 class EntraWorkloadIAM(DefaultExtension):
 
@@ -65,24 +84,25 @@ class EntraWorkloadIAM(DefaultExtension):
         scope_cluster = ScopeCluster(release_namespace=release_namespace)
         ext_scope = Scope(cluster=scope_cluster, namespace=None)
 
-        # Create new dictionary where the keys of the user settings are all lowercase (but leave the
-        # others alone in case they are specific settings that have to be passed to the Helm chart).
-        validated_settings = dict()
-        all_user_settings = [CONFIG_SETTINGS_USER_TRUST_DOMAIN, CONFIG_SETTINGS_USER_TENANT_ID,
-                             CONFIG_SETTINGS_USER_LOCAL_AUTHORITY, CONFIG_SETTINGS_USER_JOIN_TOKEN]
-        for key, value in configuration_settings.items():
-            if key.lower() in all_user_settings:
-                validated_settings[key.lower()] = value
-            else:
-                validated_settings[key] = value
-        config_settings = validated_settings
+        # Turn configuration setting keys into lowercase to make them case-insensitive
+        config_settings = settings_dict_to_lowercase(configuration_settings)
+        config_protected_settings = settings_dict_to_lowercase(configuration_protected_settings)
 
         # Get user configuration values and remove them from the dictionary so that they aren't
         # passed to the Helm chart
         trust_domain = config_settings.pop(CONFIG_SETTINGS_USER_TRUST_DOMAIN, None)
         tenant_id = config_settings.pop(CONFIG_SETTINGS_USER_TENANT_ID, None)
         local_authority = config_settings.pop(CONFIG_SETTINGS_USER_LOCAL_AUTHORITY, None)
+
+        # The join token can also be provided by the user. However, we must prevent them from
+        # passing it as a regular configuration setting, it must be passed as a protected setting.
         join_token = config_settings.pop(CONFIG_SETTINGS_USER_JOIN_TOKEN, None)
+        if join_token is not None:
+            raise InvalidArgumentValueError(
+                "The join token must be provided with --config-protected-settings, not "
+                "--configuration-settings.")
+
+        join_token = config_protected_settings.pop(CONFIG_SETTINGS_USER_JOIN_TOKEN, None)
 
         # A trust domain name is always required
         if trust_domain is None:
@@ -106,9 +126,14 @@ class EntraWorkloadIAM(DefaultExtension):
         # Save configuration setting values to overwrite values in the Helm chart
         configuration_settings[CONFIG_SETTINGS_HELM_TRUST_DOMAIN] = trust_domain
         configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] = tenant_id
-        configuration_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] = join_token
 
-        logger.debug("Configuration settings value for Helm: %s" % str(configuration_settings))
+        if configuration_protected_settings is None:
+            configuration_protected_settings = dict()
+        configuration_protected_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] = join_token
+
+        logger.debug("Configuration settings: %s" % str(configuration_settings))
+        logger.debug("Configuration protected settings value for Helm: %s" %
+                     str(configuration_protected_settings))
 
         create_identity = True
         extension = Extension(

--- a/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
+++ b/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
@@ -166,7 +166,7 @@ class TestEntraWorkloadIAM(unittest.TestCase):
                 plan_product=None)
 
         self.assertEqual(str(context.exception),
-            "The join token must be provided with --config-protected-settings, not "
+            "'joinToken' must be provided with --config-protected-settings, not "
             "--configuration-settings.")
 
     def test_workload_iam_create_with_join_token_and_no_local_authority_success(self):
@@ -294,7 +294,7 @@ class TestEntraWorkloadIAM(unittest.TestCase):
 
         str_settings = str(settings)
         self.assertEqual(str(context.exception),
-                f"Invalid configuration settings. Either a join token or a local authority name "
+                f"Invalid configuration settings. One of 'joinToken' or 'localAuthority' "
                 "must be provided.")
 
         # Missing trust domain

--- a/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
+++ b/src/k8s-extension/azext_k8s_extension/tests/latest/test_entra_workload_iam.py
@@ -67,7 +67,7 @@ class TestEntraWorkloadIAM(unittest.TestCase):
         def mock_extension_init(_self, *, extension_type, auto_upgrade_minor_version, release_train,
                 version, scope, configuration_settings, configuration_protected_settings):
             assert(release_train == "dev")
-            assert(configuration_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
+            assert(configuration_protected_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TRUST_DOMAIN] == mock_trust_domain_name)
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
@@ -107,13 +107,16 @@ class TestEntraWorkloadIAM(unittest.TestCase):
             CONFIG_SETTINGS_USER_TRUST_DOMAIN: mock_trust_domain_name,
             CONFIG_SETTINGS_USER_LOCAL_AUTHORITY: mock_local_authority_name,
             CONFIG_SETTINGS_USER_TENANT_ID: mock_tenant_id,
+        }
+
+        protected_settings = {
             CONFIG_SETTINGS_USER_JOIN_TOKEN: mock_join_token,
         }
 
         def mock_extension_init(_self, *, extension_type, auto_upgrade_minor_version, release_train,
                 version, scope, configuration_settings, configuration_protected_settings):
             assert(release_train == "dev")
-            assert(configuration_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
+            assert(configuration_protected_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TRUST_DOMAIN] == mock_trust_domain_name)
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
@@ -130,11 +133,41 @@ class TestEntraWorkloadIAM(unittest.TestCase):
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
                 release_train='dev', version='0.1.0', target_namespace=None,
                 release_namespace=None, configuration_settings=settings,
+                configuration_protected_settings=protected_settings,
+                configuration_settings_file=None, configuration_protected_settings_file=None,
+                plan_name=None, plan_publisher=None, plan_product=None)
+            self.assertEqual(name, 'workload-iam')
+
+    def test_workload_iam_create_with_join_token_as_regular_configuration_setting(self):
+        """
+        Test that, when the user provides a join token as a regular configuration setting, the
+        Create() method fails and asks the user to pass it as a configuration protected setting.
+        """
+
+        mock_trust_domain_name = 'any_trust_domain_name.com'
+        mock_tenant_id = 'any_tenant_id'
+        mock_join_token = 'any_join_token'
+
+        settings = {
+            CONFIG_SETTINGS_USER_TRUST_DOMAIN: mock_trust_domain_name,
+            CONFIG_SETTINGS_USER_TENANT_ID: mock_tenant_id,
+            CONFIG_SETTINGS_USER_JOIN_TOKEN: mock_join_token,
+        }
+
+        with self.assertRaises(InvalidArgumentValueError) as context:
+            workload_iam = EntraWorkloadIAM()
+            workload_iam.Create(cmd=None, client=None, resource_group_name=None,
+                cluster_name=None, name='workload-iam', cluster_type=None, cluster_rp=None,
+                extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
+                release_train='dev', version='0.1.0', target_namespace=None,
+                release_namespace=None, configuration_settings=settings,
                 configuration_protected_settings=None, configuration_settings_file=None,
                 configuration_protected_settings_file=None, plan_name=None, plan_publisher=None,
                 plan_product=None)
-            self.assertEqual(name, 'workload-iam')
 
+        self.assertEqual(str(context.exception),
+            "The join token must be provided with --config-protected-settings, not "
+            "--configuration-settings.")
 
     def test_workload_iam_create_with_join_token_and_no_local_authority_success(self):
         """
@@ -150,14 +183,17 @@ class TestEntraWorkloadIAM(unittest.TestCase):
 
         settings = {
             CONFIG_SETTINGS_USER_TRUST_DOMAIN: mock_trust_domain_name,
-            CONFIG_SETTINGS_USER_JOIN_TOKEN: mock_join_token,
             CONFIG_SETTINGS_USER_TENANT_ID: mock_tenant_id,
+        }
+
+        protected_settings = {
+            CONFIG_SETTINGS_USER_JOIN_TOKEN: mock_join_token,
         }
 
         def mock_extension_init(_self, *, extension_type, auto_upgrade_minor_version, release_train,
                 version, scope, configuration_settings, configuration_protected_settings):
             assert(release_train == "dev")
-            assert(configuration_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
+            assert(configuration_protected_settings[CONFIG_SETTINGS_HELM_JOIN_TOKEN] == mock_join_token);
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TRUST_DOMAIN] == mock_trust_domain_name)
             assert(configuration_settings[CONFIG_SETTINGS_HELM_TENANT_ID] == mock_tenant_id)
 
@@ -174,9 +210,9 @@ class TestEntraWorkloadIAM(unittest.TestCase):
                 extension_type=None, scope='cluster', auto_upgrade_minor_version=None,
                 release_train='dev', version='0.1.0', target_namespace=None,
                 release_namespace=None, configuration_settings=settings,
-                configuration_protected_settings=None, configuration_settings_file=None,
-                configuration_protected_settings_file=None, plan_name=None, plan_publisher=None,
-                plan_product=None)
+                configuration_protected_settings=protected_settings,
+                configuration_settings_file=None, configuration_protected_settings_file=None,
+                plan_name=None, plan_publisher=None, plan_product=None)
             self.assertEqual(name, 'workload-iam')
 
     def test_workload_iam_create_with_trust_domain_local_authority_no_tenant_id(self):


### PR DESCRIPTION
Instead of using regular configuration settings for the join token, use protected configuration settings.

This is an example of the output when the extension is installed with the changes in the PR (the value of the join token isn't shown):

![image](https://github.com/AzureArcForKubernetes/azure-cli-extensions/assets/6632664/31cbb9d5-7981-4b99-b7ce-f17e467bf450)

![image](https://github.com/AzureArcForKubernetes/azure-cli-extensions/assets/6632664/58251fb9-e460-4a33-89d5-714101bbc39e)

---

### General Guidelines

- [X] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [X] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [X] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)