### PR TITLE
feat: Add support for all clouds except air gapped for microsoft.azuremonitor.containers.metrics in ARC clusters (managed prometheus)

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/azuremonitorprofile.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
-from azure.cli.core.azclierror import InvalidArgumentValueError
+from azure.cli.core.azclierror import AzCLIError
 from knack.util import CLIError
 from .helper import (
     get_cluster_region,
@@ -65,16 +65,8 @@ def ensure_azure_monitor_profile_prerequisites(
         cluster_type
 ):
     cloud_name = cmd.cli_ctx.cloud.name
-    if cloud_name.lower() == 'azurechinacloud':
-        raise CLIError("Azure China Cloud is not supported for the Azure Monitor Metrics extension")
-
-    if cloud_name.lower() == "azureusgovernment":
-        if safe_key_check('grafana-resource-id', configuration_settings):
-            grafana_resource_id = safe_value_get('grafana-resource-id', configuration_settings)
-        if grafana_resource_id is not None:
-            if grafana_resource_id != "":
-                raise InvalidArgumentValueError("Azure US Government cloud does not support Azure Managed Grarfana yet. Please follow this documenation for enabling it via the public cloud : aka.ms/ama-grafana-link-ff")
-
+    if cloud_name.lower() == "ussec" or cloud_name.lower() == "usdod":
+        raise AzCLIError(f"{cloud_name} does not support Azure Managed Prometheus yet.")
     # Do RP registrations if required
     rp_registrations(cmd, cluster_subscription)
     link_azure_monitor_profile_artifacts(

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/azuremonitorprofile.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/azuremonitorprofile.py
@@ -65,7 +65,7 @@ def ensure_azure_monitor_profile_prerequisites(
         cluster_type
 ):
     cloud_name = cmd.cli_ctx.cloud.name
-    if cloud_name.lower() == "ussec" or cloud_name.lower() == "usdod":
+    if cloud_name.lower() == "ussec" or cloud_name.lower() == "usnat" or cloud_name.lower() == "usdod":
         raise AzCLIError(f"{cloud_name} does not support Azure Managed Prometheus yet.")
     # Do RP registrations if required
     rp_registrations(cmd, cluster_subscription)


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az k8s-extension create --name azuremonitor-metrics -g kaveesharc -c kaveesharc -t connectedClusters --extension-type Microsoft.AzureMonitor.Containers.Metrics --configuration-settings azure-monitor-workspace-resource-id="{amw_id}" AzureMonitorMetrics.KubeStateMetrics.MetricAnnotationsAllowList="pods=[k8s-annotation-1,k8s-annotation-n]"`

`az k8s-extension delete --name azuremonitor-metrics -g kaveesharc -c kaveesharc -t connectedClusters`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
