### PR TITLE
fix: update default region for azure monitor metrics extension in mooncake

### DIFF
--- a/src/k8s-extension/HISTORY.rst
+++ b/src/k8s-extension/HISTORY.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+1.7.1
+++++++++++++++++++
+* microsoft.azuremonitor.containers.metrics: Update default region for azure monitor metrics extension in mooncake
+
 1.7.0
 ++++++++++++++++++
 * microsoft.workloadiam: Enhanced security by utilizing protected configuration settings for the join token instead of regular configuration settings.

--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/deaults.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/azuremonitormetrics/deaults.py
@@ -8,7 +8,7 @@ from knack.util import CLIError
 def get_default_region(cmd):
     cloud_name = cmd.cli_ctx.cloud.name
     if cloud_name.lower() == 'azurechinacloud':
-        raise CLIError("Azure China Cloud is not supported for the Azure Monitor Metrics addon")
+        return "chinanorth3"
     if cloud_name.lower() == 'azureusgovernment':
         return "usgovvirginia"
     return "eastus"

--- a/src/k8s-extension/setup.py
+++ b/src/k8s-extension/setup.py
@@ -33,7 +33,7 @@ CLASSIFIERS = [
 # TODO: Add any additional SDK dependencies here
 DEPENDENCIES = []
 
-VERSION = "1.7.0"
+VERSION = "1.7.1"
 
 with open("README.rst", "r", encoding="utf-8") as f:
     README = f.read()


### PR DESCRIPTION
---
This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command

`az k8s-extension create --name azuremonitor-metrics -g kaveesharc -c kaveesharc -t connectedClusters --extension-type Microsoft.AzureMonitor.Containers.Metrics --configuration-settings azure-monitor-workspace-resource-id="{amw_id}" AzureMonitorMetrics.KubeStateMetrics.MetricAnnotationsAllowList="pods=[k8s-annotation-1,k8s-annotation-n]"`

`az k8s-extension delete --name azuremonitor-metrics -g kaveesharc -c kaveesharc -t connectedClusters`


### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
