### PR TITLE
Adding CLI Configuration for DisableInformerCache Flag

### DIFF
--- a/src/k8s-extension/azext_k8s_extension/partner_extensions/DataProtectionKubernetes.py
+++ b/src/k8s-extension/azext_k8s_extension/partner_extensions/DataProtectionKubernetes.py
@@ -22,6 +22,7 @@ class DataProtectionKubernetes(DefaultExtension):
            - Backup storage location (required)
            - Resource Requests (optional)
            - Resource Limits (optional)
+           - Disable Informer Cache (optional)
         """
         self.TENANT_ID = "credentials.tenantId"
         self.BACKUP_STORAGE_ACCOUNT_CONTAINER = "configuration.backupStorageLocation.bucket"
@@ -34,6 +35,7 @@ class DataProtectionKubernetes(DefaultExtension):
         self.RESOURCE_LIMIT_MEMORY = "resources.limits.memory"
         self.BACKUP_STORAGE_ACCOUNT_USE_AAD = "configuration.backupStorageLocation.config.useAAD"
         self.BACKUP_STORAGE_ACCOUNT_STORAGE_ACCOUNT_URI = "configuration.backupStorageLocation.config.storageAccountURI"
+        self.DISABLE_INFORMER_CACHE = "configuration.disableInformerCache"
 
         self.blob_container = "blobContainer"
         self.storage_account = "storageAccount"
@@ -45,6 +47,7 @@ class DataProtectionKubernetes(DefaultExtension):
         self.memory_limit = "memoryLimit"
         self.use_aad = "useAAD"
         self.storage_account_uri = "storageAccountURI"
+        self.disable_informer_cache = "disableInformerCache"
 
         self.configuration_mapping = {
             self.blob_container.lower(): self.BACKUP_STORAGE_ACCOUNT_CONTAINER,
@@ -56,7 +59,8 @@ class DataProtectionKubernetes(DefaultExtension):
             self.cpu_limit.lower(): self.RESOURCE_LIMIT_CPU,
             self.memory_limit.lower(): self.RESOURCE_LIMIT_MEMORY,
             self.use_aad.lower(): self.BACKUP_STORAGE_ACCOUNT_USE_AAD,
-            self.storage_account_uri.lower(): self.BACKUP_STORAGE_ACCOUNT_STORAGE_ACCOUNT_URI
+            self.storage_account_uri.lower(): self.BACKUP_STORAGE_ACCOUNT_STORAGE_ACCOUNT_URI,
+            self.disable_informer_cache.lower(): self.DISABLE_INFORMER_CACHE
         }
 
         self.bsl_configuration_settings = [


### PR DESCRIPTION
---

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
`az k8s-extension create --name azure-aks-backup --extension-type microsoft.dataprotection.kubernetes --scope cluster --cluster-type managedClusters --cluster-name <cluster name> --resource-group <rg name> --release-train stable --configuration-settings blobContainer=<container name> storageAccount=<sa name> storageAccountResourceGroup=<sa rg name> storageAccountSubscriptionId=<sa sub id>`

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
